### PR TITLE
Fix not being able to create bylines

### DIFF
--- a/bylines.php
+++ b/bylines.php
@@ -55,7 +55,6 @@ add_action( 'parse_request', array( 'Bylines\Content_Model', 'action_parse_reque
 // Admin customizations.
 add_action( 'admin_init', array( 'Bylines\Post_Editor', 'action_admin_init' ) );
 add_filter( 'manage_edit-byline_columns', array( 'Bylines\Byline_Editor', 'filter_manage_edit_byline_columns' ) );
-add_filter( 'list_table_primary_column', array( 'Bylines\Byline_Editor', 'filter_list_table_primary_column' ) );
 add_filter( 'manage_byline_custom_column', array( 'Bylines\Byline_Editor', 'filter_manage_byline_custom_column' ), 10, 3 );
 add_filter( 'user_row_actions', array( 'Bylines\Byline_Editor', 'filter_user_row_actions' ), 10, 2 );
 add_action( 'byline_edit_form_fields', array( 'Bylines\Byline_Editor', 'action_byline_edit_form_fields' ) );

--- a/src/Byline_Editor.php
+++ b/src/Byline_Editor.php
@@ -29,22 +29,13 @@ class Byline_Editor {
 		$new_columns = array();
 		foreach ( $columns as $key => $title ) {
 			if ( 'name' === $key ) {
-				$new_columns['byline_name']       = __( 'Name', 'bylines' );
+				$new_columns['name']              = $title;
 				$new_columns['byline_user_email'] = __( 'Email', 'bylines' );
 			} else {
 				$new_columns[ $key ] = $title;
 			}
 		}
 		return $new_columns;
-	}
-
-	/**
-	 * Set our custom name column as the primary column
-	 *
-	 * @return string
-	 */
-	public static function filter_list_table_primary_column() {
-		return 'byline_name';
 	}
 
 	/**
@@ -55,14 +46,7 @@ class Byline_Editor {
 	 * @param int    $term_id     Term ID.
 	 */
 	public static function filter_manage_byline_custom_column( $retval, $column_name, $term_id ) {
-		if ( 'byline_name' === $column_name ) {
-			$byline = Byline::get_by_term_id( $term_id );
-			$avatar = get_avatar( $byline->user_email, 32 );
-			// Such hack. Lets us reuse the rendering without duplicate code.
-			$term          = get_term_by( 'id', $term_id, 'byline' );
-			$wp_list_table = _get_list_table( 'WP_Terms_List_Table' );
-			$retval        = $avatar . ' ' . $wp_list_table->column_name( $term );
-		} elseif ( 'byline_user_email' === $column_name ) {
+		if ( 'byline_user_email' === $column_name ) {
 			$byline = Byline::get_by_term_id( $term_id );
 			if ( $byline->user_email ) {
 				$retval = '<a href="' . esc_url( 'mailto:' . $byline->user_email ) . '">' . esc_html( $byline->user_email ) . '</a>';


### PR DESCRIPTION
This fixes an issue where the use of `_get_list_table( 'WP_Terms_List_Table' )` triggered a php notice which made the creation of a byline via ajax fail. The only thing this PR changes is to remove the gravatar from the bylines list.