### PR TITLE
Fix 'Could not update the meta value' rest issue

### DIFF
--- a/src/Rest.php
+++ b/src/Rest.php
@@ -65,7 +65,7 @@ class Rest {
 		foreach ( get_bylines( $object_id ) as $byline ) {
 			$display_name        = $byline->display_name;
 			$term                = is_a( $byline, 'WP_User' ) ? 'u' . $byline->ID : $byline->term_id;
-			$byline_display_data = (object) array(
+			$byline_display_data = array(
 				'value' => (string) $term,
 				'label' => $display_name,
 			);


### PR DESCRIPTION
Remove the casting of $byline_display_data from an array to an object, this triggered an error in WP_REST_Meta_Fields::update_meta_value where old value was an array of objects and new value was an array of arrays.