### PR TITLE
Use tax label in post column

### DIFF
--- a/src/Post_Editor.php
+++ b/src/Post_Editor.php
@@ -35,7 +35,7 @@ class Post_Editor {
 		foreach ( $columns as $key => $title ) {
 			$new_columns[ $key ] = $title;
 			if ( 'title' === $key ) {
-				$new_columns['bylines'] = __( 'Bylines', 'bylines' );
+				$new_columns['bylines'] = get_taxonomy( 'byline' )->labels->name;
 			}
 
 			if ( 'author' === $key ) {


### PR DESCRIPTION
Instead of hard coding "Bylines" as the heading of the posts list column, use the taxonomy name label.